### PR TITLE
Improved html parsing and user error reporting

### DIFF
--- a/acmd/tools/users.py
+++ b/acmd/tools/users.py
@@ -69,7 +69,8 @@ def list_users(server, options):
 def create_user(server, options, username):
     """ curl -u admin:admin -FcreateUser= -FauthorizableId=testuser -Frep:password=abc123
             http://localhost:4502/libs/granite/security/post/authorizables """
-    assert len(username) > 0
+    assert len(username) > 0, "You must specify a username"
+    assert options.password, "Please specify a password with the -p option"
     form_data = {
         'createUser': '',
         'authorizableId': username,

--- a/acmd/util/html.py
+++ b/acmd/util/html.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 """ Helper functions for parsing legacy services returning html content. """
 
+import re
 from xml.dom import minidom
 
 
@@ -19,6 +20,9 @@ def parse_value(src, node_name, attr):
         return it's text content. """
     attr_name, attr_val = split(attr)
 
+    # If the AEM link checker for some reason finds invalid links in the response, it will put img elements that are not
+    # properly XML terminated, so for this purpose we simply remove all IMG tags there are.
+    src = re.sub(r'<img.*?>', '', src)
     doc = minidom.parseString(src)
     for elem in doc.getElementsByTagName(node_name):
         if elem.attributes.get(attr_name) and \


### PR DESCRIPTION
- `user create` will now fail assertion if password is missing before attempting to create the user
- If the AEM link checker for some reason finds invalid links in the response, it will put img elements that are not properly XML terminated, so for this purpose we simply remove all IMG tags there are.